### PR TITLE
40 read status

### DIFF
--- a/backend/routes/chat/posts.js
+++ b/backend/routes/chat/posts.js
@@ -1,10 +1,10 @@
 // posts.js
 import express from 'express';
-import authMiddleware from '../middleware/auth.js';
-import pool from "../config/db.js";
-import supabase from '../lib/supabase.js';
+import authMiddleware from '../../middleware/auth.js';
+import pool from '../../config/db.js';
+import supabase from '../../lib/supabase.js';
 const router = express.Router();
-import { createReplyNotification } from './notifications.js';
+import { createReplyNotification } from '../notifications.js';
 
 
 
@@ -682,5 +682,6 @@ router.delete('/:id', authMiddleware, async (req, res) => {
       res.status(500).json({ error: error.message });
     }
   });
+
 
 export default router;

--- a/backend/routes/chat/read-status.js
+++ b/backend/routes/chat/read-status.js
@@ -1,0 +1,70 @@
+// routes/chat/read-status.js
+import express from 'express';
+import supabase from '../../lib/supabase.js';
+const router = express.Router();
+import authMiddleware from '../../middleware/auth.js';
+
+// Mark thread as read
+router.post('/:threadId', authMiddleware, async (req, res) => {
+    try {
+      const auth0Id = req.auth?.payload?.sub;
+      const { threadId } = req.params;
+      
+      console.log('THREAD READ UPDATE:', {
+        auth0Id,
+        threadId,
+        timestamp: new Date().toISOString()
+      });
+      
+      const { data, error } = await supabase
+            .from('thread_read_status')
+            .upsert(
+                {
+                auth0_id: auth0Id,
+                thread_id: threadId,
+                last_read_at: new Date().toISOString()
+                },
+                { onConflict: 'auth0_id,thread_id' }
+            )
+            .select();
+      
+      console.log('THREAD READ RESULT:', { data, error });
+      
+      if (error) throw error;
+      
+      res.json({ success: true, data });
+    } catch (error) {
+      console.error('Error marking thread as read:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+// Get read status for current user
+router.get('/', authMiddleware, async (req, res) => {
+  try {
+    const auth0Id = req.auth?.payload?.sub;
+    
+    if (!auth0Id) {
+      return res.json({});
+    }
+    
+    const { data, error } = await supabase
+      .from('thread_read_status')
+      .select('thread_id, last_read_at')
+      .eq('auth0_id', auth0Id);
+    
+    if (error) throw error;
+    
+    const readStatus = {};
+    data.forEach(item => {
+      readStatus[item.thread_id] = item.last_read_at;
+    });
+    
+    res.json(readStatus);
+  } catch (error) {
+    console.error('Error fetching read status:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/backend/routes/users/users.js
+++ b/backend/routes/users/users.js
@@ -96,7 +96,7 @@ router.post('/profile', async (req, res) => {
 router.get('/', authMiddleware, async (req, res) => {
   try {
       const { rows } = await pool.query('SELECT auth0_id, username, email FROM users ORDER BY username');
-      console.log('Users fetched:', rows);
+    //  console.log('Users fetched:', rows);
       res.json(rows);
   } catch (error) {
       console.error('Error fetching users:', error);

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,7 +20,7 @@ import usersRouter from './routes/users/users.js';
 import favoritesRouter from './routes/users/favorites.js';
 import authRoutes from './routes/auth.js';
 import sessionMusiciansRouter from './routes/sessionmusicians.js';
-import postsRouter from './routes/posts.js';
+import postsRouter from './routes/chat/posts.js';
 import tagsRouter from './routes/tags.js';
 import tcupgcalRouter from './routes/tcupgcal.js';
 import pledgesRouter from './routes/pledges.js';
@@ -30,6 +30,7 @@ import notificationsRouter, { createReplyNotification } from './routes/notificat
 import updatesRouter from './routes/updates.js';
 import contactRouter from './routes/contact.js';
 import uploadRouter from './routes/upload.js';
+import readStatusRouter from './routes/chat/read-status.js'
 
 // 2) Optional debugging/logging to confirm environment vars are loaded
 console.log('NODE_ENV:', process.env.NODE_ENV);
@@ -127,6 +128,8 @@ app.use('/api/notifications', notificationsRouter)
 app.use('/api/updates', updatesRouter)
 app.use('/api/contact', contactRouter)
 app.use('/api/upload', uploadRouter)
+app.use('/api/read-status', readStatusRouter);
+
 
 
 

--- a/frontend/src/pages/Chat/ViewSingleThread.js
+++ b/frontend/src/pages/Chat/ViewSingleThread.js
@@ -78,6 +78,27 @@ const ViewSingleThread = () => {
       console.error('Error fetching user roles:', error);
     }
   };
+
+  useEffect(() => {
+    if (user && threadId) {
+      markThreadAsRead();
+    }
+  }, [threadId, user]);
+  
+  // Add this function to your component's functions
+  const markThreadAsRead = async () => {
+    try {
+      const token = await getAccessTokenSilently();
+      await fetch(`${apiUrl}/read-status/${threadId}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+    } catch (error) {
+      console.error('Error marking thread as read:', error);
+    }
+  };
   
   useEffect(() => {
     if (highlightedReplyId) {


### PR DESCRIPTION
# Implementing Read/Unread Thread Status for Forum

## Solution Created
- **Database:** Added `thread_read_status` table in Supabase tracking which threads users have read
- **Backend:** Created API routes for marking threads as read and getting read status
- **Frontend:** Added logic to display unread threads in bold text, read threads in normal font

## Implementation Details
1. **Supabase Table:**
   - Records user's auth0_id, thread_id, and last_read_at timestamp
   - Uses unique constraint on auth0_id + thread_id

2. **Backend Routes:**
   - POST `/read-status/:threadId` to mark threads as read
   - GET `/read-status` to retrieve all read statuses for current user

3. **Frontend Components:**
   - ViewSingleThread marks threads as read upon viewing
   - ListOfAllThreads compares timestamps to determine read status
   - Bold styling applied to unread threads

## Issues Fixed
- Fixed API URL path consistency (/api duplications)
- Added proper auth middleware to routes
- Fixed upsert operation with onConflict parameter
- Ensured proper timestamp comparisons

The solution successfully tracks when users read threads and shows bold titles for threads with unread content.